### PR TITLE
修复插件概述中的错别字

### DIFF
--- a/md/扩展/概述.md
+++ b/md/扩展/概述.md
@@ -99,7 +99,7 @@ Extensions can be written in either TypeScript or JavaScript.  VS Code offers a 
 
 ## 安装和分享  Install and Share
 
-一旦你拥有了一个可以正常工作的插件，你可以[安装或者分享给其他人](/docs/extensions/install-extension.md)。我们支持本利淡妆，私有分享，或者发布到公共的[插件商店](/docs/editor/extension-gallery.md)。
+一旦你拥有了一个可以正常工作的插件，你可以[安装或者分享给其他人](/docs/extensions/install-extension.md)。我们支持本地安装，私有分享，或者发布到公共的[插件商店](/docs/editor/extension-gallery.md)。
 
 Once you have a working extension, you can [install it or share it with others](/docs/extensions/install-extension.md).   We support local installation, private sharing, or publishing to the public [Extension Marketplace](/docs/editor/extension-gallery.md).
 


### PR DESCRIPTION
修复了一些错别字。
我们支持本利淡妆，私有分享，或者发布到公共的插件商店。
更改为
我们支持本地安装，私有分享，或者发布到公共的插件商店。